### PR TITLE
Better isOpen Check (RK-8299)

### DIFF
--- a/src/main/java/org/rookout/java_websocket/client/WebSocketClient.java
+++ b/src/main/java/org/rookout/java_websocket/client/WebSocketClient.java
@@ -769,6 +769,7 @@ public abstract class WebSocketClient extends AbstractWebSocket implements Runna
 			} finally {
 				closeSocket();
 				writeThread = null;
+				//NOTE::BK I believe there is a bug in this flow. engine.close() should also be called
 			}
 		}
 
@@ -847,7 +848,7 @@ public abstract class WebSocketClient extends AbstractWebSocket implements Runna
 
 	@Override
 	public boolean isOpen() {
-		return engine.isOpen();
+		return (socket != null && !socket.isClosed()) && engine.isOpen();
 	}
 
 	@Override


### PR DESCRIPTION
There is a flow where the connection is closed; writeThread is assigned with null and the socket is closed - but the engire is lets as is.
This is causing us not to identify TCP issues.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
